### PR TITLE
README.md: no need to always display User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Make the following modifications to your .muttrc:
 ```
 set display_filter="/PATH/TO/lorifier.py"
 ignore *
-unignore from date subject to cc x-date x-uri User-Agent message-id
+unignore from date subject to cc x-date x-uri message-id
 ```
 
 Note that if Message-ID is not unignored, mutt will not pass it to the


### PR DESCRIPTION
User-Agent has nothing to do with the filter, so no need to not ignore
it.  Fix up the documentation to reflect that.

Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>